### PR TITLE
[Docs] 이슈 템플릿 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.yml
@@ -8,7 +8,7 @@ body:
       label: "⚠️ Please check for similar bug reports"
       description: "이미 보고된 버그 중 중복되는 것이 없는지 확인해 주세요."
       options:
-        - label: "이전에 보고된 [버그 리포트](https://github.com/boostcampaitech7/level2-nlp-generationfornlp-nlp-06-lv3/issues?q=label%3A%22Type%3A+Bug%22+) 중 중복되는 것이 없습니다."
+        - label: "이전에 보고된 [버그 리포트](https://github.com/boostcampaitech7/level2-nlp-generationfornlp-nlp-06-lv3/issues?q=+is%3Aissue+label%3A%22Type%3A+Bug%22+) 중 중복되는 것이 없습니다."
           required: true
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/discussion-template.yml
+++ b/.github/ISSUE_TEMPLATE/discussion-template.yml
@@ -8,7 +8,7 @@ body:
       label: "⚠️ Please check that this topic hasn't been discussed already."
       description: "Make sure to search through previous discussions to avoid duplicates. This helps keep our discussion organized and focused."
       options:
-        - label: "이전에 진행된 [논의](https://github.com/boostcampaitech7/level2-nlp-generationfornlp-nlp-06-lv3/issues?q=label%3A%22Type%3A+Discussion%22+)들을 확인했으며, 유사한 주제가 없습니다."
+        - label: "이전에 진행된 [논의](https://github.com/boostcampaitech7/level2-nlp-generationfornlp-nlp-06-lv3/issues?q=is%3Aissue+label%3A%22Type%3A+Discussion%22+)들을 확인했으며, 유사한 주제가 없습니다."
           required: true
         - label: "한 가지 주제만 제출했습니다. 여러 주제를 다룰 경우, 각각 개별적으로 논의 이슈를 생성하겠습니다."
           required: true

--- a/.github/ISSUE_TEMPLATE/exp-result-template.yml
+++ b/.github/ISSUE_TEMPLATE/exp-result-template.yml
@@ -1,6 +1,6 @@
 name: Experiment Results
 description: Share and discuss experiment results related to the project.
-labels: ["experiment"]
+labels: ["Type: Experiment"]
 body:
   - type: checkboxes
     id: no-duplicate-experiment
@@ -8,7 +8,7 @@ body:
       label: "⚠️ Please check that similar experiment results haven't been shared already."
       description: "This helps us avoid redundancy and keeps experiment records organized."
       options:
-        - label: "이전에 공유된 [실험 결과](https://github.com/boostcampaitech7/level2-nlp-generationfornlp-nlp-06-lv3/issues?q=label%3Aexperiment+) 중 중복되는 것이 없습니다."
+        - label: "이전에 공유된 [실험 결과](https://github.com/boostcampaitech7/level2-nlp-generationfornlp-nlp-06-lv3/issues?q=+is%3Aissue+label%3A%22Type%3A+Experiment%22+) 중 중복되는 것이 없습니다."
           required: true
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/new-feature-tamplate.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature-tamplate.yml
@@ -1,6 +1,6 @@
 name: New Feature Request
 description: Suggest a new feature or enhancement for the project.
-labels: ["enhancement"]
+labels: ["Type: Enhancement"]
 body:
   - type: checkboxes
     id: no-duplicate-feature
@@ -8,7 +8,7 @@ body:
       label: "⚠️ Please check for similar feature requests"
       description: "비슷한 기능이 이미 제안된 적이 없는지 확인해 주세요."
       options:
-        - label: s"이전에 제안된 [기능 요청](https://github.com/boostcampaitech7/level2-nlp-generationfornlp-nlp-06-lv3/issues?q=label%3Aenhancement+) 중 중복되는 것이 없습니다."
+        - label: s"이전에 제안된 [기능 요청](https://github.com/boostcampaitech7/level2-nlp-generationfornlp-nlp-06-lv3/issues?q=+is%3Aissue+label%3A%22Type%3A+Enhancement%22+) 중 중복되는 것이 없습니다."
           required: true
 
   - type: input


### PR DESCRIPTION
## 📝 Summary

#6 에서 제안된 새로운 Labels에 맞춰서 issue template을 수정했습니다.

## ✅ Checklist

- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- [x] 문서 업데이트가 포함되었습니다.
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

![스크린샷 2024-11-12 141319](https://github.com/user-attachments/assets/b9c378f1-512b-4db7-b193-14e91d47211a)

깃허브에서 기본적으로 제공하는 9개의 labels입니다

<br/>
<br/>

![스크린샷 2024-11-12 141229](https://github.com/user-attachments/assets/5242b573-41ce-4ea6-ab47-d86e8471929b)

현재는 [Sane GitHub Labels](https://medium.com/@dave_lunny/sane-github-labels-c5d2e6004b63)에서 제안된 방식으로 Labels을 구성했습니다.
<br/>
<br/>


```yml
name: Discussion
description: Share and discuss ideas or questions related to the project.
labels: ["Type: Discussion"]
```
이에 맞춰서 yml 파일들의 labels 값을 수정했습니다.
<br/>

## 💡 Notice

아직 프로젝트가 본격적으로 시작되기 전이라, 임의로 라벨과 템플릿을 수정해봤습니다.
피어세션에서 시연해보고 다른 분들의 의견을 반영해서 최종 merge하겠습니다.

## 🔗 Related Issue(s)

close #6 
