### PR TITLE
[Docs] 이슈 템플릿에 기본 라벨 및 타이틀 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-title: "[BUG]"
+title: "[BUG] "
 description: Report a bug or issue in the project.
 labels: ["Type: Bug", "Priority: Medium", "Status: Pending"]
 body:

--- a/.github/ISSUE_TEMPLATE/discussion-template.yml
+++ b/.github/ISSUE_TEMPLATE/discussion-template.yml
@@ -1,5 +1,5 @@
 name: Discussion
-title: [DISC]
+title: "[DISC] "
 description: Share and discuss ideas or questions related to the project.
 labels: ["Type: Discussion", "Priority: Medium", "Status: Pending"]
 body:

--- a/.github/ISSUE_TEMPLATE/exp-result-template.yml
+++ b/.github/ISSUE_TEMPLATE/exp-result-template.yml
@@ -1,5 +1,5 @@
 name: Experiment Results
-title: "[EXP]"
+title: "[EXP] "
 description: Share and discuss experiment results related to the project.
 labels: ["Type: Experiment", "Priority: Medium", "Status: Pending"]
 body:

--- a/.github/ISSUE_TEMPLATE/new-feature-tamplate.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature-tamplate.yml
@@ -1,5 +1,5 @@
 name: New Feature Request
-title: "[FEAT]"
+title: "[FEAT] "
 description: Suggest a new feature or enhancement for the project.
 labels: ["Type: Enhancement", "Priority: Medium", "Status: Pending"]
 body:


### PR DESCRIPTION
## 📝 Summary

#6 에 대한 팀 회의 결과에 따라
- 이슈 생성 시에 [BUG], [DISC], [EXP], [FEAT] 타이틀이 제목에 자동으로 붙도록 했습니다.
- Priority: Medium, Status: Pending을 기본 라벨로 추가했습니다.


## ✅ Checklist


- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- [x] 문서 업데이트가 포함되었습니다.
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

```yml
title: "[BUG] "
labels: ["Type: Enhancement", "Priority: Medium", "Status: Pending"]
```
- title 항목이 추가되었습니다.
- Type 뒤에 2개의 기본 라벨이 추가되었습니다.



## 💡 Notice

필수 작성란 옆에 빨간 *이 안뜨는 문제가 있는데 원인을 파악중입니다.

## 🔗 Related Issue(s)

#6 
