### PR TITLE
[Fix] dataframe 결측값 처리가 되지 않아 발생하던 버그 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ set_seed(42)
 
 df = pd.read_csv("data/train.csv")
 df["choices"] = df["choices"].apply(literal_eval)
+df["question_plus"] = df["question_plus"].fillna("")
 
 model = AutoModelForCausalLM.from_pretrained(
     "beomi/gemma-ko-2b",
@@ -265,6 +266,7 @@ trainer.train()
 # TODO Test Data 경로 입력
 test_df = pd.read_csv("data/test.csv")
 test_df["choices"] = test_df["choices"].apply(literal_eval)
+test_df["question_plus"] = test_df["question_plus"].fillna("")
 
 test_dataset = []
 for i, row in test_df.iterrows():


### PR DESCRIPTION
## 📝 Summary

dataframe에서 결측값을 `""`으로 처리하여 기존 코드에서 예상치 않게 잘못 동작하던 버그를 수정하였습니다.

<!--
PR의 주요 내용을 간단히 요약해주세요.
예: 로그인 기능에서 사용자 세션 관리 개선.
-->

## ✅ Checklist

<!--
해당되는 항목을 [x]로 만들어주세요.
예: - [x] 관련 이슈가 명시되어 있습니다.

해당되지 않는 항목은 앞뒤로 ~를 붙여서 취소선을 그어주세요.
예: - ~[ ] 관련 이슈가 명시되어 있습니다.~
-->

- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- ~[ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

`train.csv`와 `test.csv`에 대해서 `Dataframe`을 불러온 뒤 `qeustion_plus`가 존재하지 않는 데이터에 `fillna` 적용하였습니다.

이러한 결측치 핸들링이 없어서 오류가 발생하고 있었습니다.

`train` 데이터에 대해서는 `dataset`으로 변환 후 `prompt` 적용하며 `if dataset[i]["question_plus"]:` 부분이 잘 적용되었습니다:

```python
dataset = Dataset.from_pandas(df)

processed_dataset = []
for i in range(len(dataset)):
    choices_string = "\n".join([f"{idx + 1} - {choice}" for idx, choice in enumerate(dataset[i]["choices"])])

    # <보기>가 있을 때
    if dataset[i]["question_plus"]:
        user_message = PROMPT_QUESTION_PLUS.format(
            paragraph=dataset[i]["paragraph"],
            question=dataset[i]["question"],
            question_plus=dataset[i]["question_plus"],
            choices=choices_string,
        )
    # <보기>가 없을 때
    else:
        user_message = PROMPT_NO_QUESTION_PLUS.format(
            paragraph=dataset[i]["paragraph"],
            question=dataset[i]["question"],
            choices=choices_string,
        )

    # chat message 형식으로 변환
    processed_dataset.append(
        {
            "id": dataset[i]["id"],
            "messages": [
                {"role": "system", "content": "지문을 읽고 질문의 답을 구하세요."},
                {"role": "user", "content": user_message},
                {"role": "assistant", "content": f"{dataset[i]['answer']}"},
            ],
            "label": dataset[i]["answer"],
        }
    )
```

반면, `test` 데이터에 대해서는 `Dataframe`에 대해 바로 `prompt`를 적용하여 `if row["question_plus"]:`가 오류를 일으키고 있었습니다:

```python
test_dataset = []
for i, row in test_df.iterrows():
    choices_string = "\n".join([f"{idx + 1} - {choice}" for idx, choice in enumerate(row["choices"])])
    len_choices = len(row["choices"])

    # <보기>가 있을 때
    if row["question_plus"]:
        user_message = PROMPT_QUESTION_PLUS.format(
            paragraph=row["paragraph"],
            question=row["question"],
            question_plus=row["question_plus"],
            choices=choices_string,
        )
    # <보기>가 없을 때
    else:
        user_message = PROMPT_NO_QUESTION_PLUS.format(
            paragraph=row["paragraph"],
            question=row["question"],
            choices=choices_string,
        )

    test_dataset.append(
        {
            "id": row["id"],
            "messages": [
                {"role": "system", "content": "지문을 읽고 질문의 답을 구하세요."},
                {"role": "user", "content": user_message},
            ],
            "len_choices": len_choices,
        }
    )
```

`null` 데이터에 대해 `row["question_plus"]`는 `nan`를 가지며 조건문에서 `True`로 취급됩니다. 이로 인해 `test` 데이터에 대해 모든 데이터가 <보기> 가 있는 걸로 간주되어 잘못된 prompt로 만들어져 추론되었고, 점수 하락의 원인이 되었습니다.

따라서 `fillna`로 결측값을 확실히 처리하였고 버그를 해결하였습니다.

<!--
PR의 변경 사항을 구체적으로 설명해주세요.
예: 이번 변경 사항에는 로그인 세션 시간 연장 및 오류 메시지 개선이 포함됩니다.
-->

## 💡 Notice (Optional)

사실 `test`에 대해서만 `fillna`를 적용하기만 하면 해결되지만, `train`도 나중에 데이터 작업하다가 문제가 생길걸 대비해 결측치 처리를 함께 해두었습니다.

<!--
리뷰어가 알아야 할 추가적인 사항이나 주의점이 있다면 작성해주세요.
예: 이 기능은 인증 모듈과 호환성을 고려해야 합니다.
-->

## 🔗 Related Issue(s)

close #14 

<!--
이 PR과 관련된 이슈나 기존 PR이 있다면 번호를 언급하고, 필요 시 close할 이슈도 명시해주세요.
예: 관련 이슈 - #33, close #27
-->
