### PR TITLE
[Chore] Streamlit app에서 디폴트 주소 세팅

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 HF_TOKEN={your_hf_token}
+STREAMLIT_DATA_PATH={streamlit_data_path}

--- a/analysis_dashboard.py
+++ b/analysis_dashboard.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
             df = pd.read_csv(uploaded_file)
         else:
             # 첨부 파일이 없으면 기본적으로 train.csv에 대한 분석을 출력합니다.
-            df = pd.read_csv(os.getenv("streamlit_default_train_path"))
+            df = pd.read_csv(os.getenv("STREAMLIT_DATA_PATH"))
         # 데이터 요약
         with tab1:
             display_data_summary(df)


### PR DESCRIPTION
## 📝 Summary

기존에 하드코딩된 디폴트 데이터셋 주소를 `dotenv`로 관리하도록 방식이 변경되었습니다.


## ✅ Checklist

- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- ~[ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

```python
# .env
streamlit_default_train_path="data/train_v2.0.1.csv"
```

```python
# analysis_dashboard.py
import os
from dotenv import load_dotenv
...
load_dotenv()
...
df = pd.read_csv(os.getenv("streamlit_default_train_path"))
```
`.env` 파일은 이미 `.gitignore`에 추가되어 있어 Git에 추적되지 않습니다.

이를 활용해 디폴트 데이터셋 경로를 `.env`에서 관리하도록 변경하여,
데이터셋 버저닝이 업데이트되더라도 Streamlit 앱 코드는 추가 수정 없이 동작하도록 개선했습니다.

![스크린샷 2024-11-21 183219](https://github.com/user-attachments/assets/9e00a1cf-0f3e-4f01-8aa2-6c092852fd3f)

배포된 주소로 들어가시면 `train_v2.0.1.csv`에 대한 정보가 기본적으로 출력되는걸 확인하실 수 있습니다.

## 💡 Notice (Optional)

PR이 merge되면, 제가 공용서버의 `.env`를 수정해서 다시 배포하겠습니다.

Streamlit app에 대한 추가 기능 건의는 언제나 환영입니다.

## 🔗 Related Issue(s)

#27 
