### PR TITLE
[Feat] wandb 로깅 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,5 @@ baseline*.ipynb
 .DS_Store
 configs/*.yaml
 !configs/config.yaml
+
+wandb/

--- a/configs/config.py
+++ b/configs/config.py
@@ -57,6 +57,7 @@ class SftConfig:
     num_train_epochs: int
     learning_rate: float
     weight_decay: float
+    logging_strategy: str
     logging_steps: int
     save_strategy: str
     eval_strategy: str
@@ -68,8 +69,6 @@ class SftConfig:
 @dataclass
 class WandbConfig:
     project: str
-    entity: str
-    name: str
 
 
 @dataclass

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -23,27 +23,25 @@ sft:
   per_device_train_batch_size: 1
   per_device_eval_batch_size: 1
   num_train_epochs: 3
-  learning_rate: 2.0e-5 # 지수 자릿수 앞부분을 실수 형태로 .을 사용해 작성
+  learning_rate: 2.0e-5 # 지수 자릿수 앞부분을 실수 형태로 작성 ('2'-> x, '2.0'-> o)
   weight_decay: 0.01
-  logging_steps: 1
+  logging_strategy: "steps" # epoch or steps, epoch의 경우 logging_steps 무시
+  logging_steps: 100
   save_strategy: "epoch"
   eval_strategy: "epoch"
   save_total_limit: 1
   save_only_model: true
-  report_to: "none"
-  # report_to: "wandb" # wandb로 변경하여 로그를 기록합니다.
+  report_to: "wandb" # none or wandb, wandb로 변경하여 로그를 기록합니다.
 
 wandb:
-  project: "your_wandb_project_name"
-  entity: "your_wandb_entity_name"
-  name: "experiment_name"
+  project: "MMLU"
 
 train:
-  data_path: "data/train.csv"
-  valid_data_path: "data/valid.csv"
+  data_path: "data/train_v2.0.1.csv" # wandb 로깅 사용시 파일명 변겅 금지(데이터 버전 정보 사용)
+  valid_data_path: "data/valid_v2.0.1.csv"
   valid_output_path: "data/valid_output.csv"
 
 inference:
-  model_path: "outputs/gemma-ko-2b"
-  data_path: "data/test.csv"
+  model_path: "outputs/gemma-ko-2b" # 학습된 모델로 변경 필요
+  data_path: "data/test_v1.0.2.csv"
   output_path: "data/output.csv"

--- a/configs/config_factories.py
+++ b/configs/config_factories.py
@@ -27,6 +27,7 @@ def create_sft_config(sft_config: SftConfig) -> SFTConfig:
         num_train_epochs=sft_config.num_train_epochs,
         learning_rate=sft_config.learning_rate,
         weight_decay=sft_config.weight_decay,
+        logging_strategy=sft_config.logging_strategy,
         logging_steps=sft_config.logging_steps,
         save_strategy=sft_config.save_strategy,
         eval_strategy=sft_config.eval_strategy,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,4 @@ target-version = ["py310"]  # 지원하는 Python 버전
 profile = "black"  # black 스타일과 호환되도록 설정
 line_length = 120  # 한 줄의 최대 길이
 include_trailing_comma = true  # 마지막 쉼표 추가
+known_third_party = ["wandb"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ wikipedia-api
 # Visualization Packages
 streamlit
 streamlit-option-menu
+wandb
 
 # Development Packages
 tqdm

--- a/train.py
+++ b/train.py
@@ -6,6 +6,7 @@ import dotenv
 from sklearn.metrics import accuracy_score
 from trl import SFTTrainer
 
+import wandb
 from configs import Config, create_peft_config, create_sft_config
 from data_loaders import build_data_loader
 from evaluation import compute_metrics, preprocess_logits_for_metrics
@@ -14,13 +15,18 @@ from utils import set_seed
 
 
 def train(config: Config):
-    # # wandb 초기화
-    # wandb.init(
-    #     project=config.wandb.project,
-    #     entity=config.wandb.entity,
-    #     name=config.wandb.name,
-    #     config=config.raw_config,  # 설정값을 wandb에 로깅
-    # )
+    # wandb 초기화
+    wandb.init(
+        project=config.wandb.project,
+        name=(
+            f"{config.model.name_or_path.split('/')[1]}/"
+            f"epoch-{config.sft.num_train_epochs}/"
+            f"LoRA_r-{config.peft.r}/"
+            f"max_seq_length-{config.sft.max_seq_length}/"
+            f"data-{config.train.data_path.split('_')[1].split('.csv')[0]}"
+        ),
+        config=config.raw_config,
+    )
 
     model, tokenizer = load_model_and_tokenizer(config.model.name_or_path, config.common.device)
 

--- a/train.py
+++ b/train.py
@@ -3,10 +3,10 @@ import os
 import shutil
 
 import dotenv
+import wandb
 from sklearn.metrics import accuracy_score
 from trl import SFTTrainer
 
-import wandb
 from configs import Config, create_peft_config, create_sft_config
 from data_loaders import build_data_loader
 from evaluation import compute_metrics, preprocess_logits_for_metrics


### PR DESCRIPTION
## 📝 Summary

<!--
PR의 주요 내용을 간단히 요약해주세요.
예: 로그인 기능에서 사용자 세션 관리 개선.
-->

원활한 실험을 위해 wandb 로깅 기능 구현.

## ✅ Checklist

<!--
해당되는 항목을 [x]로 만들어주세요.
예: - [x] 관련 이슈가 명시되어 있습니다.

해당되지 않는 항목은 앞뒤로 ~를 붙여서 취소선을 그어주세요.
예: - ~[ ] 관련 이슈가 명시되어 있습니다.~
-->

- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- ~[ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

<!--
PR의 변경 사항을 구체적으로 설명해주세요.
예: 이번 변경 사항에는 로그인 세션 시간 연장 및 오류 메시지 개선이 포함됩니다.
-->

### 1. `train.py`에서의 wandb 로깅 기능 구현
- `train loss`, `eval_loss`, `eval_accuracy` 등 학습에 사용되는 실험 수치를 wandb에서 볼 수 있게 되었습니다.

### 2. `config.yaml` 과 기타 `config` 파일 수정
- wandb 로깅 구현에 사용되는 파라미터와 코드 일부를 수정했습니다.

### 3. `requirements.txt`, `.gitignore` 수정
- `wandb` 패키지를 `requirements.txt` 목록에 등록했습니다.
- 자동으로 생성되는 `wandb` 캐시 폴더를 `.gitignore`에 등록해 git 관리 대상에서 제외했습니다.

## 💡 Notice (Optional)

<!--
리뷰어가 알아야 할 추가적인 사항이나 주의점이 있다면 작성해주세요.
예: 이 기능은 인증 모듈과 호환성을 고려해야 합니다.
-->

- 첫 실행 시 https://wandb.ai/authorize 링크에서 wandb API key를 복사해 터미널에 붙여 넣어야 합니다.
-  코드에서 데이터 버전 정보를 활용하므로 `config.yaml`에 학습 데이터 경로 설정 시 파일명을 변경하지 않고 그대로 사용해야 합니다. (e.g. `train_v2.0.1.csv`)
- wandb 로깅을 사용하고 싶지 않다면 `config.yaml`의 `report_to` 값을 `none`으로 설정하면 됩니다.

## 🔗 Related Issue(s)
close #24
<!--
이 PR과 관련된 이슈나 기존 PR이 있다면 번호를 언급하고, 필요 시 close할 이슈도 명시해주세요.
예: 관련 이슈 - #33, close #27
-->
