### PR TITLE
[Feat] bits and bytes config 추가

### DIFF
--- a/configs/config.py
+++ b/configs/config.py
@@ -16,6 +16,7 @@ class Config:
 
         self.model = ModelConfig(**self.raw_config["model"])
         self.common = CommonConfig(**self.raw_config["common"])
+        self.bnb = BnbConfig(**self.raw_config["bnb"])
         self.peft = PeftConfig(**self.raw_config["peft"])
         self.sft = SftConfig(**self.raw_config["sft"])
         self.wandb = WandbConfig(**self.raw_config["wandb"])
@@ -28,12 +29,22 @@ class ModelConfig:
     name_or_path: str
     response_template: str
     without_system_role: str
+    torch_dtype: str
 
 
 @dataclass
 class CommonConfig:
     seed: int
     device: str
+
+
+@dataclass
+class BnbConfig:
+    load_in_8bit: bool
+    load_in_4bit: bool
+    bnb_4bit_compute_dtype: str
+    bnb_4bit_use_double_quant: bool
+    bnb_4bit_quant_type: str
 
 
 @dataclass

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -2,10 +2,18 @@ model:
   name_or_path: "beomi/gemma-ko-2b"
   response_template: "<start_of_turn>model\n"
   without_system_role: false
+  torch_dtype: "float16" # float32, float16, bfloat16 / 모델의 기본 데이터 타입
 
 common:
   seed: 42
   device: "cuda"
+
+bnb:
+  load_in_8bit: false
+  load_in_4bit: false
+  bnb_4bit_compute_dtype: "float16" # float16, float32, bfloat16 / 4 bit 양자화 데이터의 계산 데이터 타입
+  bnb_4bit_use_double_quant: false # true 시 더블 양자화(메모리 사용량 감소, 시간 더 걸림)
+  bnb_4bit_quant_type: "nf4" # nf4, fp4
 
 peft:
   r: 6

--- a/configs/config_factories.py
+++ b/configs/config_factories.py
@@ -1,7 +1,19 @@
 from peft import LoraConfig
+from transformers import BitsAndBytesConfig
 from trl import SFTConfig
 
-from configs import PeftConfig, SftConfig
+from configs import BnbConfig, PeftConfig, SftConfig
+from utils import str_to_dtype
+
+
+def create_bnb_config(bnb_config: BnbConfig) -> BitsAndBytesConfig:
+    return BitsAndBytesConfig(
+        load_in_8bit=bnb_config.load_in_8bit,
+        load_in_4bit=bnb_config.load_in_4bit,
+        bnb_4bit_compute_dtype=str_to_dtype(bnb_config.bnb_4bit_compute_dtype),
+        bnb_4bit_use_double_quant=bnb_config.bnb_4bit_use_double_quant,
+        bnb_4bit_quant_type=bnb_config.bnb_4bit_quant_type,
+    )
 
 
 def create_peft_config(peft_config: PeftConfig) -> LoraConfig:

--- a/inference.py
+++ b/inference.py
@@ -1,18 +1,15 @@
 import argparse
 
 import dotenv
-from peft import AutoPeftModelForCausalLM
-from transformers import AutoTokenizer
 
 from configs import Config
 from data_loaders import build_data_loader
-from models import predict
+from models import load_model_and_tokenizer, predict
 from utils import set_seed
 
 
 def inference(config: Config):
-    model = AutoPeftModelForCausalLM.from_pretrained(config.inference.model_path, device_map="auto")
-    tokenizer = AutoTokenizer.from_pretrained(config.inference.model_path)
+    model, tokenizer = load_model_and_tokenizer(config.inference.model_path, config)
 
     data_loader = build_data_loader("inference", tokenizer, config)
 

--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ def train(config: Config):
         project=config.wandb.project,
         name=(
             f"{config.model.name_or_path.split('/')[1]}/"
+            f"{'4bit' if config.bnb.load_in_4bit else ('8bit' if config.bnb.load_in_8bit else 'no_qunatization')}/"
             f"epoch-{config.sft.num_train_epochs}/"
             f"LoRA_r-{config.peft.r}/"
             f"max_seq_length-{config.sft.max_seq_length}/"

--- a/train.py
+++ b/train.py
@@ -28,7 +28,7 @@ def train(config: Config):
         config=config.raw_config,
     )
 
-    model, tokenizer = load_model_and_tokenizer(config.model.name_or_path, config.common.device)
+    model, tokenizer = load_model_and_tokenizer(config.model.name_or_path, config)
 
     data_loader = build_data_loader("train", tokenizer, config)
 

--- a/utils/util.py
+++ b/utils/util.py
@@ -13,3 +13,14 @@ def set_seed(random_seed):
     torch.backends.cudnn.benchmark = False
     np.random.seed(random_seed)
     random.seed(random_seed)
+
+
+def str_to_dtype(dtype_str: str):
+    if dtype_str == "float16":
+        return torch.float16
+    elif dtype_str == "float32":
+        return torch.float32
+    elif dtype_str == "bfloat16":
+        return torch.bfloat16
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype_str}")


### PR DESCRIPTION
## 📝 Summary

<!--
PR의 주요 내용을 간단히 요약해주세요.
예: 로그인 기능에서 사용자 세션 관리 개선.
-->

config 설정을 통해 bits and bytes 패키지로 양자화를 할 수 있도록 기능을 추가하였습니다.

## ✅ Checklist

<!--
해당되는 항목을 [x]로 만들어주세요.
예: - [x] 관련 이슈가 명시되어 있습니다.

해당되지 않는 항목은 앞뒤로 ~를 붙여서 취소선을 그어주세요.
예: - ~[ ] 관련 이슈가 명시되어 있습니다.~
-->

- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- ~[ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

<!--
PR의 변경 사항을 구체적으로 설명해주세요.
예: 이번 변경 사항에는 로그인 세션 시간 연장 및 오류 메시지 개선이 포함됩니다.
-->

- `config.yaml`에 bnb 설정이 추가되었습니다.
```yaml
bnb:
  load_in_8bit: false
  load_in_4bit: false
  bnb_4bit_compute_dtype: "float16" # float16, float32, bfloat16 / 4 bit 양자화 데이터의 계산 데이터 타입
  bnb_4bit_use_double_quant: false # true 시 더블 양자화(메모리 사용량 감소, 시간 더 걸림)
  bnb_4bit_quant_type: "nf4" # nf4, fp4
```

4bit 및 8bit 양자화를 할 수 있으며, 4bit 양자화 시 세부 로직을 선택할 수 있습니다.

- wandb 로그에 실험 이름안에 양자화 타입도 기록하도록 변경하였습니다.
  - 4bit/8bit/no_qunatization 중 하나로 타입이 기록됩니다.
- `inference.py`에서도 양자화 설정을 통해 기 학습된 모델을 불러오게 하였습니다.
  - 멘토님의 조언에 따르면 양자화하여 학습한 모델을 추론도 양자화하여 진행하는 것이 성능 손실이 일어나지 않는다고 하여 이부분을 개선하였습니다.

## 💡 Notice (Optional)

`from_pretrained`로 모델을 불러올 때 `BitsAndBytesConfig` 객체를 `quantization_config`로 넣으면 양자화 설정이 로드되며 학습 속도가 느려지는 현상을 발견하였습니다.

따라서, `load_model` 함수에서 `load_in_4bit` 혹은 `load_in_8bit` 둘 중 하나가 True 인 경우(양자화가 필요한 경우) 에만 quantization_config 객체를 만들도록 하였습니다.(없다면 None을 넣어 평범하게 모델을 불러와 학습 속도에 영향을 주지 않습니다.)

추가적으로 torch_dtype도 config에서 수정가능하게 파라미터화 시켰습니다.

<!--
리뷰어가 알아야 할 추가적인 사항이나 주의점이 있다면 작성해주세요.
예: 이 기능은 인증 모듈과 호환성을 고려해야 합니다.
-->

## 🔗 Related Issue(s)

<!--
이 PR과 관련된 이슈나 기존 PR이 있다면 번호를 언급하고, 필요 시 close할 이슈도 명시해주세요.
예: 관련 이슈 - #33, close #27
-->

#23 