### PR TITLE
[Feat] `inference.py`를 통한 validation 기능 추가

### DIFF
--- a/data_loaders/data_loader_factory.py
+++ b/data_loaders/data_loader_factory.py
@@ -14,7 +14,8 @@ def build_data_loader(type: str, tokenizer: PreTrainedTokenizerFast, config: Con
         else:
             return TrainDataLoader(config, tokenizer)
     else:  # inference
+        data_path = config.train.valid_data_path if type == "validation" else config.inference.data_path
         if config.model.without_system_role:
-            return InferenceDataLoaderWithoutSystem(config.inference.data_path, tokenizer)
+            return InferenceDataLoaderWithoutSystem(data_path, tokenizer)
         else:
-            return InferenceDataLoader(config.inference.data_path, tokenizer)
+            return InferenceDataLoader(data_path, tokenizer)

--- a/data_loaders/inference/inference_data_loader.py
+++ b/data_loaders/inference/inference_data_loader.py
@@ -11,7 +11,7 @@ class InferenceDataLoader(BaseDataLoader):
     def build_single_data(self, data: pd.Series, user_prompt: str):
         len_choices = len(data["choices"])
 
-        return {
+        result = {
             "id": data["id"],
             "messages": [
                 {"role": "system", "content": "지문을 읽고 질문의 답을 구하세요."},
@@ -19,3 +19,7 @@ class InferenceDataLoader(BaseDataLoader):
             ],
             "len_choices": len_choices,
         }
+        if "answer" in data:
+            result["label"] = data["answer"]
+
+        return result

--- a/data_loaders/inference/inference_data_loader_without_system.py
+++ b/data_loaders/inference/inference_data_loader_without_system.py
@@ -11,10 +11,14 @@ class InferenceDataLoaderWithoutSystem(InferenceDataLoader):
     def build_single_data(self, data: pd.Series, user_prompt: str):
         len_choices = len(data["choices"])
 
-        return {
+        result = {
             "id": data["id"],
             "messages": [
                 {"role": "user", "content": "지문을 읽고 질문의 답을 구하세요.\n" + user_prompt},
             ],
             "len_choices": len_choices,
         }
+        if "answer" in data:
+            result["label"] = data["answer"]
+
+        return result

--- a/inference.py
+++ b/inference.py
@@ -1,6 +1,7 @@
 import argparse
 
 import dotenv
+from sklearn.metrics import accuracy_score
 
 from configs import Config
 from data_loaders import build_data_loader
@@ -20,6 +21,9 @@ def inference(config: Config, validation: bool = False):
 
     if validation:
         prediction.to_csv(config.train.valid_output_path, index=False)
+        accuracy = accuracy_score(prediction["label"].astype(str), prediction["answer"].astype(str))
+        print("\nFinal Validation results:")
+        print(f"Accuracy: {accuracy:4f}")
     else:
         prediction.to_csv(config.inference.output_path, index=False)
 

--- a/inference.py
+++ b/inference.py
@@ -8,14 +8,20 @@ from models import load_model_and_tokenizer, predict
 from utils import set_seed
 
 
-def inference(config: Config):
+def inference(config: Config, validation: bool = False):
     model, tokenizer = load_model_and_tokenizer(config.inference.model_path, config)
 
-    data_loader = build_data_loader("inference", tokenizer, config)
+    if validation:
+        data_loader = build_data_loader("validation", tokenizer, config)
+    else:
+        data_loader = build_data_loader("inference", tokenizer, config)
 
     prediction = predict(model, tokenizer, data_loader.dataset)
 
-    prediction.to_csv(config.inference.output_path, index=False)
+    if validation:
+        prediction.to_csv(config.train.valid_output_path, index=False)
+    else:
+        prediction.to_csv(config.inference.output_path, index=False)
 
 
 if __name__ == "__main__":
@@ -23,6 +29,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config_file", type=str, default="config.yaml")
+    parser.add_argument("-v", "--validation", action="store_true")
     args = parser.parse_args()
 
     try:
@@ -34,4 +41,4 @@ if __name__ == "__main__":
 
     set_seed(config.common.seed)
 
-    inference(config)
+    inference(config, validation=args.validation)


### PR DESCRIPTION
## 📝 Summary

<!--
PR의 주요 내용을 간단히 요약해주세요.
예: 로그인 기능에서 사용자 세션 관리 개선.
-->

기존 validation set에 대한 추론 로직이 잘못되어 있었던 것을 inference.py를 통해 실행하도록 옮기며 수정완료하였습니다.


## ✅ Checklist

<!--
해당되는 항목을 [x]로 만들어주세요.
예: - [x] 관련 이슈가 명시되어 있습니다.

해당되지 않는 항목은 앞뒤로 ~를 붙여서 취소선을 그어주세요.
예: - ~[ ] 관련 이슈가 명시되어 있습니다.~
-->

- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- ~[ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

<!--
PR의 변경 사항을 구체적으로 설명해주세요.
예: 이번 변경 사항에는 로그인 세션 시간 연장 및 오류 메시지 개선이 포함됩니다.
-->

`python inference.py -v` 를 통해 valid.csv에 대한 성능을 확인해볼 수 있습니다.

- `argparser`로 새로운 `--validation` 혹은 `-v` flag로 valid에대해 추론 할지 여부를 선택할 수 있습니다.
- 평범하게 `inference.py`를 실행 시 `test.csv`에 대해 추론을 합니다.
- validation의 경우, 최종 accuracy를 print문을 통해 로그로 확인 가능합니다.
  - validation 데이터셋의 경우 label 정보를 보존할 필요가 있어 관련 코드를 추가하였습니다.



## Validation과 리더보드 비교

![image](https://github.com/user-attachments/assets/7ef40dde-b5da-485b-baa0-0bb1e9dd6604)

![image](https://github.com/user-attachments/assets/e95db177-8453-4882-a646-6aa51319323d)

---

![image](https://github.com/user-attachments/assets/d61c911a-fc4f-41ee-977b-6936c88c7d09)

![image](https://github.com/user-attachments/assets/bbeb8444-24af-418c-a934-04bbb5a9f90a)

| Model         | Validation Score | Leaderboard (Public Test) Score |
|---------------|------------------|----------------------------------|
| Gemma-2-9b-it | 0.877500         | 0.6959                          |
| Qwen 2.5      | 0.845000         | 0.6705                          |


## 💡 Notice (Optional)

<!--
리뷰어가 알아야 할 추가적인 사항이나 주의점이 있다면 작성해주세요.
예: 이 기능은 인증 모듈과 호환성을 고려해야 합니다.
-->

inference.py에서 validation을 끼워넣다 보니 코드가 살짝 더러워진 감이 있는데 양해 부탁드립니다.

## 🔗 Related Issue(s)

<!--
이 PR과 관련된 이슈나 기존 PR이 있다면 번호를 언급하고, 필요 시 close할 이슈도 명시해주세요.
예: 관련 이슈 - #33, close #27
-->

close #44 