### PR TITLE
[Feat] early stop 기능 구현

### DIFF
--- a/configs/config.py
+++ b/configs/config.py
@@ -17,6 +17,7 @@ class Config:
         self.model = ModelConfig(**self.raw_config["model"])
         self.common = CommonConfig(**self.raw_config["common"])
         self.bnb = BnbConfig(**self.raw_config["bnb"])
+        self.earlystop = EarlystopConfig(**self.raw_config["earlystop"])
         self.peft = PeftConfig(**self.raw_config["peft"])
         self.sft = SftConfig(**self.raw_config["sft"])
         self.wandb = WandbConfig(**self.raw_config["wandb"])
@@ -48,6 +49,14 @@ class BnbConfig:
 
 
 @dataclass
+class EarlystopConfig:
+    metric_for_best_model: str
+    early_stopping_patience: int
+    early_stopping_threshold: float
+    greater_is_better: bool
+
+
+@dataclass
 class PeftConfig:
     r: int
     lora_alpha: int
@@ -72,6 +81,7 @@ class SftConfig:
     logging_steps: int
     save_strategy: str
     eval_strategy: str
+    load_best_model_at_end: bool
     save_total_limit: int
     save_only_model: bool
     report_to: str

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -15,6 +15,12 @@ bnb:
   bnb_4bit_use_double_quant: false # true 시 더블 양자화(메모리 사용량 감소, 시간 더 걸림)
   bnb_4bit_quant_type: "nf4" # nf4, fp4
 
+earlystop:
+  metric_for_best_model: "eval_loss" # 모니터링할 지표 이름
+  early_stopping_patience: 1 # 개선되지 않는 에폭 수
+  early_stopping_threshold: 0.0 # 개선으로 간주할 최소 변화량
+  greater_is_better: false # 지표가 높을수록 좋은 경우 True
+
 peft:
   r: 6
   lora_alpha: 8
@@ -37,6 +43,7 @@ sft:
   logging_steps: 100
   save_strategy: "epoch"
   eval_strategy: "epoch"
+  load_best_model_at_end: true
   save_total_limit: 1
   save_only_model: true
   report_to: "wandb" # none or wandb, wandb로 변경하여 로그를 기록합니다.

--- a/configs/config_factories.py
+++ b/configs/config_factories.py
@@ -43,6 +43,7 @@ def create_sft_config(sft_config: SftConfig) -> SFTConfig:
         logging_steps=sft_config.logging_steps,
         save_strategy=sft_config.save_strategy,
         eval_strategy=sft_config.eval_strategy,
+        load_best_model_at_end=sft_config.load_best_model_at_end,
         save_total_limit=sft_config.save_total_limit,
         save_only_model=sft_config.save_only_model,
         report_to=sft_config.report_to,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,2 @@
+from .earlystop import *
 from .util import *

--- a/utils/earlystop.py
+++ b/utils/earlystop.py
@@ -1,0 +1,33 @@
+from transformers import TrainerCallback
+
+
+class CustomEarlyStoppingCallback(TrainerCallback):
+    def __init__(self, monitor, patience, threshold, greater_is_better):
+        self.monitor = monitor
+        self.patience = patience
+        self.threshold = threshold
+        self.greater_is_better = greater_is_better
+        self.best_score = None
+        self.num_bad_epochs = 0
+
+    def on_evaluate(self, args, state, control, metrics, **kwargs):
+        current_score = metrics.get(self.monitor)
+        if current_score is None:
+            return
+
+        if self.best_score is None:
+            self.best_score = current_score
+            return
+
+        if self.greater_is_better:
+            improvement = current_score - self.best_score
+        else:
+            improvement = self.best_score - current_score
+
+        if improvement > self.threshold:
+            self.best_score = current_score
+            self.num_bad_epochs = 0
+        else:
+            self.num_bad_epochs += 1
+            if self.num_bad_epochs >= self.patience:
+                control.should_training_stop = True


### PR DESCRIPTION
## 📝 Summary
config 설정을 통해 early stop 기능으로 `eval loss` 값이 상승 시 조기 학습 종료 기능을 추가하였습니다.
<!--
PR의 주요 내용을 간단히 요약해주세요.
예: 로그인 기능에서 사용자 세션 관리 개선.
-->

## ✅ Checklist

<!--
해당되는 항목을 [x]로 만들어주세요.
예: - [x] 관련 이슈가 명시되어 있습니다.

해당되지 않는 항목은 앞뒤로 ~를 붙여서 취소선을 그어주세요.
예: - ~[ ] 관련 이슈가 명시되어 있습니다.~
-->

- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- ~[ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

<!--
PR의 변경 사항을 구체적으로 설명해주세요.
예: 이번 변경 사항에는 로그인 세션 시간 연장 및 오류 메시지 개선이 포함됩니다.
-->

- `config.yaml`에 earlystop 설정이 추가되었습니다.

```yaml
earlystop:
  metric_for_best_model: "eval_loss" # 모니터링할 지표 이름
  early_stopping_patience: 1 # 개선되지 않는 에폭 수
  early_stopping_threshold: 0.0 # 개선으로 간주할 최소 변화량
  greater_is_better: false # 지표가 높을수록 좋은 경우 True
```

### 사용법
- 예를 들어 2 epoch 동안 eval_loss가 개선되지 않을 경우 학습을 종료하고 싶다면 `early_stopping_patience` 값을 `2`로 설정하면 됩니다.
- 학습이 종료되면 `eval_loss` 값이 가장 낮은 시점의 모델이 자동으로 저장됩니다.
- `metric_for_best_model="eval_accuracy"`, `greater_is_better=true`로 설정하면 `eval_accuracy`가 떨어질 때를 기준으로 사용 가능합니다.
    - (`eval_loss`를 기준으로 실험하는 것이 더 권장되는 방법이라고 합니다.)
- `early_stopping_patience` 값을 증가하는 경우 `sft - num_train_epochs` 값을 기존 3에서 늘려 실험하는 것을 권장합니다.

## 💡 Notice (Optional)

<!--
리뷰어가 알아야 할 추가적인 사항이나 주의점이 있다면 작성해주세요.
예: 이 기능은 인증 모듈과 호환성을 고려해야 합니다.
-->
현재 `eval_loss` 수치가 불안정하여 early stop의 지표로써 신뢰도가 떨어지는 점 참고 부탁드립니다..🥲

## 🔗 Related Issue(s)
close #25 
<!--
이 PR과 관련된 이슈나 기존 PR이 있다면 번호를 언급하고, 필요 시 close할 이슈도 명시해주세요.
예: 관련 이슈 - #33, close #27
-->
