### PR TITLE
[Hotfix] 모델 로드시 `model.to` 대신 `deivce_map` 설정

### DIFF
--- a/models/model_loader.py
+++ b/models/model_loader.py
@@ -39,12 +39,13 @@ def load_model(model_name_or_path, config: Config) -> PreTrainedModel:
     # 모델 로드
     model = AutoModelForCausalLM.from_pretrained(
         model_name_or_path,
+        device_map="auto",
         quantization_config=quantization_config,
         torch_dtype=str_to_dtype(config.model.torch_dtype),
         trust_remote_code=True,
     )
 
-    model.to(config.common.device)
+    # model.to(config.common.device)
     return model
 
 


### PR DESCRIPTION
일부 모델 학습시 `.to`는 동작하지 않으므로 `device_map`으로 변경