### PR TITLE
[Hotfix] eval score 오류 잡았다.

### DIFF
--- a/evaluation/preprocess.py
+++ b/evaluation/preprocess.py
@@ -3,7 +3,7 @@ import torch
 from transformers import PreTrainedTokenizerFast
 
 
-def preprocess_logits_for_metrics(logits, logit_idx: list[int]):
+def preprocess_logits_for_metrics(logits, labels, logit_idx: list[int]):
     """
     모델의 logits를 조정하여 정답 토큰 부분만 출력하도록 설정하는 함수.
 

--- a/train.py
+++ b/train.py
@@ -57,7 +57,7 @@ def train(config: Config):
         data_collator=get_data_collator(tokenizer, config.model.response_template),
         tokenizer=tokenizer,
         compute_metrics=lambda eval_res: compute_metrics(eval_res, tokenizer),
-        preprocess_logits_for_metrics=lambda logits: preprocess_logits_for_metrics(logits, logit_idx),
+        preprocess_logits_for_metrics=lambda logits, labels: preprocess_logits_for_metrics(logits, labels, logit_idx),
         peft_config=peft_config,
         args=sft_config,
         callbacks=[early_stopping_callback],


### PR DESCRIPTION
## 📝 Summary

<!--
PR의 주요 내용을 간단히 요약해주세요.
예: 로그인 기능에서 사용자 세션 관리 개선.
-->
logits token index 오류 해결

## ✅ Checklist

<!--
해당되는 항목을 [x]로 만들어주세요.
예: - [x] 관련 이슈가 명시되어 있습니다.

해당되지 않는 항목은 앞뒤로 ~를 붙여서 취소선을 그어주세요.
예: - ~[ ] 관련 이슈가 명시되어 있습니다.~
-->

- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- ~[ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

<!--
PR의 변경 사항을 구체적으로 설명해주세요.
예: 이번 변경 사항에는 로그인 세션 시간 연장 및 오류 메시지 개선이 포함됩니다.
-->
끝에 숨겨진 EOS 토큰의 존재를 몰라 계속 -2번째 인덱스 토큰(<end_of_turn>)을 가져오고 있었음
![image](https://github.com/user-attachments/assets/4bdbb612-434a-4712-9914-ea18f61f1f5a)

해당 토큰의 위치가 정답 토큰 바로 옆이라 그런지 12345가 나올 확률이 -3번째 토큰에서의 12345의 확률과 비슷했나봄.

-3번째 토큰을 가져오면 정상적으로 동작. 특히 eval_accuracy 대폭 정상화
![image](https://github.com/user-attachments/assets/c8bd4025-d1ef-443d-a300-935f5838884a)

## 💡 Notice (Optional)

<!--
리뷰어가 알아야 할 추가적인 사항이나 주의점이 있다면 작성해주세요.
예: 이 기능은 인증 모듈과 호환성을 고려해야 합니다.
-->
임시방편으로 수정하여 향후 인덱스를 직접 지정하는 방식을 개선해야 함

## 🔗 Related Issue(s)
close #51 
<!--
이 PR과 관련된 이슈나 기존 PR이 있다면 번호를 언급하고, 필요 시 close할 이슈도 명시해주세요.
예: 관련 이슈 - #33, close #27
-->
