### PR TITLE
[Hotfix] 잘못 들어가 있는 `iloc` 코드 제거

### DIFF
--- a/langchain_inference.py
+++ b/langchain_inference.py
@@ -27,7 +27,6 @@ def inference(config: Config, validation: bool):
         df = pd.read_csv(config.inference.data_path)
     df["choices"] = df["choices"].apply(literal_eval)
     df["question_plus"] = df["question_plus"].fillna("")
-    df = df.iloc
 
     train_df = pd.read_csv(config.train.data_path)
     train_df["choices"] = train_df["choices"].apply(literal_eval)


### PR DESCRIPTION
## 📝 Summary

COT 로직을 정리하다가 실수로 덜 지워진 iloc 코드 때문에 제대로 실행이 안되고 있었습니다. 이부분을 수정하여 올립니다.

## 🔗 Related Issue(s)

<!--
이 PR과 관련된 이슈나 기존 PR이 있다면 번호를 언급하고, 필요 시 close할 이슈도 명시해주세요.
예: 관련 이슈 - #33, close #27
-->

#46 